### PR TITLE
`auto assign`, `codeowners` 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @yesl-kim @hyesungoh @yoycode @uussong

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,2 @@
+addReviewers: false
+addAssignees: author


### PR DESCRIPTION
- PR 작성시 작성자를 assign에 자동으로 넣도록 `auto assign`을 추가했어요
  - https://github.com/apps/auto-assign

- PR이 올라오면 리뷰어를 자동 등록하도록 코드오너를 추가했어요
  - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners